### PR TITLE
Add connect_mapped function

### DIFF
--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -137,6 +137,13 @@ class AXIInterface:
     def connect(self, slave, **kwargs):
         return connect_axi(self, slave, **kwargs)
 
+    def connect_mapped(self, slave, map_fct):
+        comb = []
+        comb += self.connect(slave, omit={"addr"})
+        comb += [slave.ar.addr.eq(map_fct(self.ar.addr))]
+        comb += [slave.aw.addr.eq(map_fct(self.aw.addr))]
+        return comb
+
     def layout_flat(self):
         return list(axi_layout_flat(self))
 


### PR DESCRIPTION
It allows connecting two different busses that has different memory mappings. Usefull when softcore in PL of Zynq7000 wants to access the DDR memory of the PS7 block.